### PR TITLE
Implement anti-aliasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Implement anti-aliasing to deal with Moiré fringes [#10](https://github.com/Cr3sp1/RayTracer/pull/10)
+
 # Version 1.0.0
 
 -   Change "demo" command into "render" command to be able to parse a scene from an input file and render it choosing a renderer [#8](https://github.com/Cr3sp1/RayTracer/pull/8)

--- a/RayTracer/RayTracer.cs
+++ b/RayTracer/RayTracer.cs
@@ -124,6 +124,10 @@ public class RenderCommand : ICommand
     [CommandOption("init-seq", 'S',
         Description = "Initial sequence value for the random number generation.")]
     public ulong InitSeq { get; init; } = 54;
+    
+    [CommandOption("anti-aliasing", 'a',
+        Description = "Number of rays to be fired per side of each pixel.")]
+    public int RaysAntiAliasing { get; init; } = 0;
 
     [CommandOption("pfm-output", 'p',
         Description = "Pfm output file path.")]
@@ -235,7 +239,7 @@ public class RenderCommand : ICommand
         }
 
         // Render the scene
-        var tracer = new ImageTracer(new HdrImage(Width, Height), scene.SceneCamera, renderer);
+        var tracer = new ImageTracer(new HdrImage(Width, Height), scene.SceneCamera, renderer, RaysAntiAliasing, new Pcg(InitState, InitSeq));
         tracer.FireAllRays();
 
         // Read rendered Pfm image

--- a/Trace.Tests/ImageTracerTests.cs
+++ b/Trace.Tests/ImageTracerTests.cs
@@ -19,7 +19,7 @@ public class ImageTracerTests
         camera = new PerspectiveCamera(aspectRatio: 2);
         scene = new World();
         renderer = new Renderer(scene);
-        tracer = new ImageTracer(image: image, camera: camera, renderer: renderer);
+        tracer = new ImageTracer(image: image, camera: camera, renderer: renderer, raysPerSide: 0, pcg: new Pcg());
         this.output = output;
     }
 
@@ -62,5 +62,18 @@ public class ImageTracerTests
         var bottomRightRay = tracer.FireRay(3, 1, 1.0f, 1.0f);
         output.WriteLine("Bottom Right Ray =\n" + bottomRightRay.At(1.0f));
         Assert.True(Point.CloseEnough(new Point(0.0f, -2.0f, -1.0f), bottomRightRay.At(1.0f)));
+    }
+    
+    // Test anti-aliasing
+    [Fact]
+    void TestAntialiasing()
+    {
+        var newImage = new HdrImage(width: 1, height: 1);
+        var newCamera = new OrthogonalCamera(aspectRatio: 1);
+        var newRenderer = new PathTracer.TestAntiAliasing(scene);
+        var newTracer = new ImageTracer(image: newImage, camera: newCamera, renderer: newRenderer, raysPerSide: 4, pcg: new Pcg());
+        
+        newTracer.FireAllRays();
+        Assert.Equal(16, newRenderer.NumRays);
     }
 }

--- a/Trace.Tests/RendererTest.cs
+++ b/Trace.Tests/RendererTest.cs
@@ -30,7 +30,7 @@ public class RendererTest
     public void TestOnOffRenderer()
     {
         var renderer = new OnOffRenderer(scene);
-        var tracer = new ImageTracer(image: image, camera: camera, renderer: renderer);
+        var tracer = new ImageTracer(image: image, camera: camera, renderer: renderer, raysPerSide: 0, pcg: new Pcg());
         tracer.FireAllRays();
 
         Assert.True(Color.CloseEnough(image.GetPixel(0, 0), Color.Black));
@@ -51,7 +51,7 @@ public class RendererTest
     public void TestFlatRenderer()
     {
         var renderer = new FlatRenderer(scene);
-        var tracer = new ImageTracer(image: image, camera: camera, renderer: renderer);
+        var tracer = new ImageTracer(image: image, camera: camera, renderer: renderer, raysPerSide: 0, pcg: new Pcg());
         tracer.FireAllRays();
 
         Assert.True(Color.CloseEnough(image.GetPixel(0, 0), Color.Black));

--- a/Trace/Renderer.cs
+++ b/Trace/Renderer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using SixLabors.ImageSharp.Formats.Png;
 
 namespace Trace;
@@ -179,5 +180,33 @@ public class PathTracer : Renderer
 
         // Return emitted light + averaged reflected light
         return emittedRadiance + 1.0f / NumRays * cumRadiance;
+    }
+    
+    /// <summary>
+    /// Class inheriting from Renderer, representing a test renderer for anti-aliasing
+    /// that always returns black.
+    /// </summary>
+    public class TestAntiAliasing : Renderer
+    {
+        public int NumRays;
+
+        // Constructor passing a scene and a color
+        public TestAntiAliasing(World world) : base(world) => NumRays = 0;
+
+        /// <summary>
+        /// Always return black.
+        /// </summary>
+        /// <param name="ray"><c>Ray</c> taken as input for the renderer.</param>
+        /// <returns><c>Color</c> black.</returns>
+        public override Color Render(Ray ray)
+        {
+            Point rayOnScreen = ray.At(1f);
+            Debug.Assert(Utils.CloseEnough(rayOnScreen.X, 0.0f, 1E-03F));
+            Debug.Assert(rayOnScreen.Y >= -1.0f && rayOnScreen.Y <= 1.0f);
+            Debug.Assert(rayOnScreen.Z >= -1.0f && rayOnScreen.Z <= 1.0f);
+            
+            NumRays += 1;
+            return new Color(0.0f, 0.0f, 0.0f);
+        }
     }
 }


### PR DESCRIPTION
This pull-request has been opened to address the problem of Moiré fringes in rendered scenes.
To-do list:

- [x] implement anti-aliasing in FireAllRays inside ImageTracer: fire a certain number of rays instead of just one inside each pixel by sampling it uniformly

- [x] add the option that lets the user set the number of rays to be fired per side of each pixel